### PR TITLE
Add application-level rate limit

### DIFF
--- a/src/GooglePlayAdvancedSearch/django/templates/index.html
+++ b/src/GooglePlayAdvancedSearch/django/templates/index.html
@@ -438,6 +438,14 @@
 </script>
 {% if isSearch %}
 	<script>
+		const testGoogleAnalysis = Promise.all([fetch('https://www.googletagmanager.com/gtag/js?id=UA-83043759-2', {mode: 'no-cors'}),
+			fetch('https://www.google-analytics.com/analytics.js', {mode: 'no-cors'})]).then(r => {
+			return new Promise(resolve => resolve(true));
+		}).catch(reason => {
+			return new Promise(resolve => resolve(false));
+		});
+
+
 		const searchResult = new Vue({
 			el: "#searchResult",
 			data: {
@@ -463,7 +471,13 @@
 
 		const startSearchTime = performance.now();
 		//When we got permission list and category list, then run the following code.
-		Promise.all([permissionPromise, categoryPromise]).then(function () {
+		Promise.all([permissionPromise, categoryPromise, testGoogleAnalysis]).then(function (results) {
+			if (results[2]) {
+				//it is a session cookie because it doesn't have expiration.
+				// `document.cookie =` is a special syntax that adds a SINGLE cookie.
+				// But reading document.cookie will return ALL cookies.
+				document.cookie = '_gaload=1';
+			}
 			fetch("/Api/Search?" + searchTool.queryString).then(r => r.json()).then(data => {
 				if (data.error) {
 					clearTimeout(searchingTimeoutHandler);

--- a/src/GooglePlayAdvancedSearch/django/web/apiHelper.py
+++ b/src/GooglePlayAdvancedSearch/django/web/apiHelper.py
@@ -2,6 +2,8 @@ import re
 
 import requests
 
+# DO NOT import any django classes here.
+# This file will be called from pytest
 from json import loads as jsonLoads
 from typing import List
 

--- a/src/GooglePlayAdvancedSearch/tests/test_selenium.py
+++ b/src/GooglePlayAdvancedSearch/tests/test_selenium.py
@@ -1,0 +1,45 @@
+import os
+import time
+
+from selenium.webdriver import Firefox
+from selenium.webdriver.firefox.options import Options
+
+testFolder = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_RateLimitWithoutGA(websiteUrl):
+	options = Options()
+	options.headless = True
+	with Firefox(options=options) as driver:
+		driver.delete_all_cookies()
+
+		# without loading Google Analysis, the 4th load of search API causes error.
+		driver.get(websiteUrl + '/Api/Search?q=')
+		assert 'Rate limit reached.' not in driver.page_source
+		driver.get(websiteUrl + '/Api/Search?q=&')
+		assert 'Rate limit reached.' not in driver.page_source
+		driver.get(websiteUrl + '/Api/Search?q=&&')
+		assert 'Rate limit reached.' not in driver.page_source
+		driver.get(websiteUrl + '/Api/Search?q=&&&')
+		assert 'Rate limit reached.' in driver.page_source
+
+
+def test_RateLimitWithGA(websiteUrl):
+	options = Options()
+	options.headless = True
+	with Firefox(options=options) as driver:
+		driver.delete_all_cookies()
+		driver.get(websiteUrl + '/search?q=')
+		time.sleep(2)
+		driver.get(websiteUrl + '/Api/Search?q=')
+		assert 'Rate limit reached.' not in driver.page_source
+		driver.get(websiteUrl + '/Api/Search?q=&')
+		assert 'Rate limit reached.' not in driver.page_source
+		driver.get(websiteUrl + '/Api/Search?q=&&')
+		assert 'Rate limit reached.' not in driver.page_source
+		driver.get(websiteUrl + '/Api/Search?q=&&&')
+		assert 'Rate limit reached.' not in driver.page_source
+
+
+if __name__ == '__main__':
+	test_RateLimitWithGA('http://127.0.0.1:8000')

--- a/src/GooglePlayAdvancedSearch/tests/test_web.py
+++ b/src/GooglePlayAdvancedSearch/tests/test_web.py
@@ -10,6 +10,12 @@ from selenium.webdriver.firefox.options import Options
 
 import GooglePlayAdvancedSearch.tests.testUtils as testUtils
 
+"""
+Test the website using regular python/requests without executing JavaScript or advanced browsing features.
+
+If you need to execute JavaScript for testing, write tests in test_selenium.py. 
+"""
+
 testFolder = os.path.dirname(os.path.abspath(__file__))
 
 


### PR DESCRIPTION
For now, if Google Analysis loads, application-level rate limit can be bypassed, let Nginx rate limit kick in.

