### PR TITLE
Remove concept of freshDays from main application

### DIFF
--- a/src/GooglePlayAdvancedSearch/django/web/Api.py
+++ b/src/GooglePlayAdvancedSearch/django/web/Api.py
@@ -108,7 +108,7 @@ def search(request: django.http.HttpRequest):
 	excludedCIds = [int(n) for n in request.GET.get('cids', '').split(',') if n != '']
 
 	try:
-		appAccessor = AppAccessor(1)
+		appAccessor = AppAccessor()
 		appInfos = appAccessor.searchApps(keyword)
 
 		needCompleteInfo = determineAppInfoCompleteness(request)
@@ -214,7 +214,7 @@ def getCompleteAppInfo(app_ids: List[str]) -> List[AppItem]:
 		# sys.version_info is a named tuple. https://docs.python.org/3/glossary.html#term-named-tuple
 		print(f'Python {tuple(sys.version_info)} may not keep dictionary insertion order. Upgrade to at least version 3.6.', file=sys.stderr)
 
-	appAccessor = AppAccessor(1)
+	appAccessor = AppAccessor()
 	with connection.cursor() as cursor:
 		# very important!
 		# connection.cursor() gives django cursor, connection.cursor().connection.cursor() gives underlying sqlite cursor.
@@ -234,7 +234,7 @@ def getCompleteAppInfo(app_ids: List[str]) -> List[AppItem]:
 				or not hasattr(os, 'WEXITSTATUS') and code2 == GooglePlayAdvancedSearch.Errors.sslErrorCode:
 			raise requests.exceptions.SSLError()
 
-		appAccessor = AppAccessor(1)
+		appAccessor = AppAccessor()
 		scraper_fail_id = []
 		for id in appsMissingInDatabase:
 			tmp = appAccessor.getCompleteAppInfo(id)

--- a/src/GooglePlayAdvancedSearch/django/web/apiHelper.py
+++ b/src/GooglePlayAdvancedSearch/django/web/apiHelper.py
@@ -27,7 +27,7 @@ def searchGooglePlay(keyword) -> List[AppItem]:
 
 	appInfos = []
 
-	appSaver = GooglePlayAdvancedSearch.DBUtils.AppAccessor(1)
+	appSaver = GooglePlayAdvancedSearch.DBUtils.AppAccessor()
 	appsData = None
 	try:
 		while True:

--- a/src/GooglePlayAdvancedSearch/scraper/pipeline.py
+++ b/src/GooglePlayAdvancedSearch/scraper/pipeline.py
@@ -4,7 +4,7 @@ import GooglePlayAdvancedSearch.DBUtils
 class DatabasePipeline(GooglePlayAdvancedSearch.DBUtils.AppAccessor):
 
 	def __init__(self, connectionString):
-		super().__init__(0)
+		super().__init__()
 
 	@classmethod
 	def from_crawler(cls, crawler):
@@ -12,16 +12,17 @@ class DatabasePipeline(GooglePlayAdvancedSearch.DBUtils.AppAccessor):
 		return cls(connectionString=crawler.settings.get('connectionString'))
 
 	def process_item(self, item, spider):
-		self.insertOrUpdateApp(item, self._AppAccessor__freshDays)
+		self.insertOrUpdateApp(item)
 		return item
 
 	def open_spider(self, spider):
 		l = ','.join(['\'' + id + '\'' for id in spider.targetAppIds])
-		freshAppIds = [r[0] for r in self._AppAccessor__cursor.execute(f"select id from app where julianday('now')-julianday(updateDate)<{self._AppAccessor__freshDays} and id in ({l})")]
-		if len(freshAppIds) > 0:
-			print(f"Request to scrape these apps:\n{spider.targetAppIds}\n")
-			spider.targetAppIds = sorted(set(spider.targetAppIds) - set(freshAppIds))
-			print(f"But some are fresh, so only scrape {spider.targetAppIds}")
+		existingAppIds = [r[0] for r in self._AppAccessor__cursor.execute(f"select id from app where isPartialInfo=0 and id in ({l})")]
+		# app information may not be up to date. It is staleAppRemover's job to remove old apps.
+		if len(existingAppIds) > 0:
+			print(f"Request to scrape these apps:\n{spider.targetAppIds}")
+			spider.targetAppIds = sorted(set(spider.targetAppIds) - set(existingAppIds))
+			print(f"But some exist, so only scrape {spider.targetAppIds}")
 		else:
 			print(f'scrape these apps:\n{spider.targetAppIds}')
 

--- a/src/GooglePlayAdvancedSearch/tests/test_AppAccessor.py
+++ b/src/GooglePlayAdvancedSearch/tests/test_AppAccessor.py
@@ -1,8 +1,3 @@
-import os
-import sqlite3
-
-import pytest
-
 from GooglePlayAdvancedSearch.DBUtils import AppAccessor
 from GooglePlayAdvancedSearch.Models import AppItem
 
@@ -15,64 +10,7 @@ def test_getCompleteAppInfoPartial():
 	app['install_fee'] = 0
 	app['app_icon'] = ''
 
-	appAccessor = AppAccessor(10)
-	appAccessor.insertOrUpdateApp(app, 0)
+	appAccessor = AppAccessor()
+	appAccessor.insertOrUpdateApp(app)
 
 	assert appAccessor.getCompleteAppInfo('testid') is None, "Database only has partial info."
-
-
-def test_getCompleteAppInfoStale(dbFilePath):
-	if os.path.exists(dbFilePath):
-		try:
-			os.remove(dbFilePath)
-		except PermissionError as e:
-			pytest.skip(str(e))
-
-	connection = sqlite3.connect(dbFilePath)
-	cursor = connection.cursor()
-	try:
-		app = AppItem()
-		app['name'] = 'test app'
-		app['id'] = 'testid'
-		app['rating'] = 1
-		app['install_fee'] = 0
-		app['app_icon'] = ''
-		app['inAppPurchases'] = True
-		app['containsAds'] = False
-		app['num_reviews'] = 1000
-		app['install_fee'] = 0
-		app['permissions'] = []
-		app['categories'] = []
-
-		appAccessor = AppAccessor(10)
-		appAccessor.insertOrUpdateApp(app, 0)
-
-		assert appAccessor.getCompleteAppInfo('testid')['rating'] == 1
-
-		cursor.execute("update app set updateDate='2000-01-01' where id='testid'")
-		connection.commit()
-		assert appAccessor.getCompleteAppInfo('testid') is None, "App data are stale, getCompleteAppInfo should return null."
-	finally:
-		cursor.execute("delete from app where id='testid'")
-
-
-def test_searchAppsStale(dbFilePath):
-	connection = sqlite3.connect(dbFilePath)
-	cursor = connection.cursor()
-
-	try:
-		app = AppItem()
-		app['name'] = 'test app'
-		app['id'] = 'testid'
-		app['rating'] = 1
-		app['install_fee'] = 0
-		app['app_icon'] = ''
-
-		appAccessor = AppAccessor(10)
-		appAccessor.insertOrUpdateApp(app, 0)
-
-		cursor.execute("update app set updateDate='2000-01-01' where id='testid'")
-		connection.commit()
-		assert next((a for a in appAccessor.searchApps('test app') if a['id'] == 'testid'), None) is None, "test app was updated on 2000-01-01, it should appear in search result."
-	finally:
-		cursor.execute("delete from app where id='testid'")


### PR DESCRIPTION
Apps in database are all considered as fresh. StaleAppRemover will remove stale apps.

Prepare for issue #22 

FreshDays handling is too complicated.