### PR TITLE
Make search duration limit dynamic

### DIFF
--- a/src/GooglePlayAdvancedSearch/DBUtils.py
+++ b/src/GooglePlayAdvancedSearch/DBUtils.py
@@ -57,14 +57,17 @@ def executeAndCreateTable(cursor, fnSqlToCreateTable, *args):
 	:param cursor:
 	:param fnSqlToCreateTable:
 	:param args: anything cursor.execute can accept.
-	:return:
+	:return: true if cursor.execute(*args) executes successfully. false if table doesn't exist.
 	"""
 	try:
 		cursor.execute(*args)
+		return True
 	except Exception as e:
 		if type(e).__name__ is 'OperationalError' and 'no such table' in str(e):
-			cursor.execute(fnSqlToCreateTable())
-			cursor.execute(*args)
+			if fnSqlToCreateTable is not None:
+				cursor.execute(fnSqlToCreateTable())
+				cursor.execute(*args)
+			return False
 		else:
 			raise e
 

--- a/src/GooglePlayAdvancedSearch/DBUtils.py
+++ b/src/GooglePlayAdvancedSearch/DBUtils.py
@@ -51,6 +51,24 @@ def saveSqlValue(str: str):
 	return str.replace('"', '').replace("'", '').replace('--', '')
 
 
+def executeAndCreateTable(cursor, fnSqlToCreateTable, *args):
+	"""
+
+	:param cursor:
+	:param fnSqlToCreateTable:
+	:param args: anything cursor.execute can accept.
+	:return:
+	"""
+	try:
+		cursor.execute(*args)
+	except Exception as e:
+		if type(e).__name__ is 'OperationalError' and 'no such table' in str(e):
+			cursor.execute(fnSqlToCreateTable())
+			cursor.execute(*args)
+		else:
+			raise e
+
+
 class AppAccessor:
 
 	def __init__(self):

--- a/src/GooglePlayAdvancedSearch/DBUtils.py
+++ b/src/GooglePlayAdvancedSearch/DBUtils.py
@@ -63,7 +63,7 @@ def executeAndCreateTable(cursor, fnSqlToCreateTable, *args):
 		cursor.execute(*args)
 		return True
 	except Exception as e:
-		if type(e).__name__ is 'OperationalError' and 'no such table' in str(e):
+		if type(e).__name__ == 'OperationalError' and 'no such table' in str(e):
 			if fnSqlToCreateTable is not None:
 				cursor.execute(fnSqlToCreateTable())
 				cursor.execute(*args)

--- a/src/GooglePlayAdvancedSearch/django/StaticFiles/js/search-result.js
+++ b/src/GooglePlayAdvancedSearch/django/StaticFiles/js/search-result.js
@@ -13,6 +13,7 @@ const searchResult = new Vue({
 		errorMessage: undefined,
 		errorType: '',
 		executionSeconds: undefined,
+		searchingPrompt: undefined,
 	},
 	methods: {
 		getPriceText(installFee, allowInAppPurchase) {
@@ -33,8 +34,10 @@ let searchingTimeoutHandler = null;
 
 const searchTimingPromise = fetch('/Api/SearchTiming').then(r => r.json()).then(data => {
 	console.log('Waiting timeout (ms): ' + (data.mean + 3 * data.std));
+
+	searchResult.searchingPrompt = `Searching... Usually finish in ${(data.mean / 1000).toFixed(1)}±${(data.std / 1000).toFixed(0)}s`;
 	searchingTimeoutHandler = setTimeout(() => searchResult.errorMessage = "Taking too long to load result. Something might be wrong.", data.mean + 3 * data.std);
-})
+});
 
 const startSearchTime = performance.now();
 //When we got permission list and category list, then run the following code.

--- a/src/GooglePlayAdvancedSearch/django/StaticFiles/js/search-result.js
+++ b/src/GooglePlayAdvancedSearch/django/StaticFiles/js/search-result.js
@@ -29,11 +29,16 @@ const searchResult = new Vue({
 	}
 });
 
-const searchingTimeoutHandler = setTimeout(() => searchResult.errorMessage = "Taking too long to load result. Something might be wrong.", 30 * 1000);
+let searchingTimeoutHandler = null;
+
+const searchTimingPromise = fetch('/Api/SearchTiming').then(r => r.json()).then(data => {
+	console.log('Waiting timeout (ms): ' + (data.mean + 3 * data.std));
+	searchingTimeoutHandler = setTimeout(() => searchResult.errorMessage = "Taking too long to load result. Something might be wrong.", data.mean + 3 * data.std);
+})
 
 const startSearchTime = performance.now();
 //When we got permission list and category list, then run the following code.
-Promise.all([permissionPromise, categoryPromise, testGoogleAnalysis]).then(function (results) {
+Promise.all([permissionPromise, categoryPromise, testGoogleAnalysis, searchTimingPromise]).then(function (results) {
 	if (results[2]) {
 		//it is a session cookie because it doesn't have expiration.
 		// `document.cookie =` is a special syntax that adds a SINGLE cookie.
@@ -45,8 +50,11 @@ Promise.all([permissionPromise, categoryPromise, testGoogleAnalysis]).then(funct
 			clearTimeout(searchingTimeoutHandler);
 			searchResult.errorMessage = data.error;
 			searchResult.errorType = "security";
+			return;
 		}
-		else if (data.apps.length === 0) {
+
+		searchResult.executionSeconds = (performance.now() - startSearchTime) / 1000;
+		if (data.apps.length === 0) {
 			clearTimeout(searchingTimeoutHandler);
 			searchResult.errorMessage = "We couldn't find anything for your search.";
 			searchResult.apps = '';
@@ -59,7 +67,6 @@ Promise.all([permissionPromise, categoryPromise, testGoogleAnalysis]).then(funct
 				return d;
 			});
 
-			searchResult.executionSeconds = (performance.now() - startSearchTime) / 1000;
 			searchResult.errorMessage = undefined;
 		}
 	});

--- a/src/GooglePlayAdvancedSearch/django/templates/index.html
+++ b/src/GooglePlayAdvancedSearch/django/templates/index.html
@@ -301,7 +301,7 @@
 						{% verbatim %}
 					</div>
 					<div class="searchingPrompt-text">
-						Searching...
+						{{ searchingPrompt }}
 					</div>
 				</template>
 			</div>

--- a/src/GooglePlayAdvancedSearch/django/web/apiHelper.py
+++ b/src/GooglePlayAdvancedSearch/django/web/apiHelper.py
@@ -99,3 +99,9 @@ CREATE TABLE Search (
 	ip TEXT NOT NULL,
 	date	TEXT NOT NULL DEFAULT (datetime('now'))
 )'''
+
+def getSqlCreateTableSearchTiming():
+	return '''
+CREATE TABLE SearchTiming (
+	"durationInMS"	INTEGER NOT NULL
+)'''

--- a/src/GooglePlayAdvancedSearch/django/web/urls.py
+++ b/src/GooglePlayAdvancedSearch/django/web/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
 	path(r'Api/Categories', Api.getCategories, name='Api/Categories'),
 	path(r'Api/Search', Api.search, name='Api/Search'),
 	path(r'Api/Version', Api.version),
-	path(r'Api/RecentSearches',Api.recentSearches, name='Api/RecentSearches'),
-	path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
+	path(r'Api/RecentSearches', Api.recentSearches, name='Api/RecentSearches'),
+	path(r'Api/SearchTiming', Api.searchTiming),
+	path(r'jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
 ]

--- a/src/GooglePlayAdvancedSearch/maintenance/staleAppRemover.py
+++ b/src/GooglePlayAdvancedSearch/maintenance/staleAppRemover.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sqlite3
+import sys
 
 
 # def clearUpBooleanColumns(cursor, columnNames):
@@ -11,17 +12,46 @@ import sqlite3
 # 			cursor.execute(f'alter table app drop column {GooglePlayAdvancedSearch.DBUtils.delimiteDBIdentifier(permission)}')
 # 			connection.commit()
 
+def cleanSearchTiming(cursor):
+	try:
+		cursor.execute('select count(*) from SearchTiming')
+		rows = cursor.fetchone()[0]
+		if rows > MAX_SEARCH_TIMING:
+			cursor.execute('delete SearchTiming where rowid<:n', {'n': rows - MAX_SEARCH_TIMING})
+			print(f'removed {cursor.rowcount} search timing records.')
+	except sqlite3.OperationalError as e:
+		if 'no such table' in str(e):
+			pass
+		else:
+			print(e, file=sys.stderr)
+
+
 MAX_RECORD_DAYS = 14
 APP_FRESH_DAYS = 7
+MAX_SEARCH_TIMING = 200
 
 if __name__ == "__main__":
 	connection = sqlite3.connect(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../data/db.sqlite3'))
 	cursor = connection.cursor()
-	cursor.execute("delete from app where updateDate<date('now','-" + str(APP_FRESH_DAYS) + " days')")
-	print(f'removed {cursor.rowcount} apps cached since {APP_FRESH_DAYS} days ago.')
+	cleanSearchTiming(cursor)
 
-	cursor.execute("delete from Search where [date]<date('now','-" + str(MAX_RECORD_DAYS) + " days')")
-	print(f'removed {cursor.rowcount} search records since {MAX_RECORD_DAYS} days ago.')
+	try:
+		cursor.execute("delete from app where updateDate<date('now','-" + str(APP_FRESH_DAYS) + " days')")
+		print(f'removed {cursor.rowcount} apps cached since {APP_FRESH_DAYS} days ago.')
+	except sqlite3.OperationalError as e:
+		if 'no such table' in str(e):
+			pass
+		else:
+			print(e, file=sys.stderr)
+
+	try:
+		cursor.execute("delete from Search where [date]<date('now','-" + str(MAX_RECORD_DAYS) + " days')")
+		print(f'removed {cursor.rowcount} search records since {MAX_RECORD_DAYS} days ago.')
+	except sqlite3.OperationalError as e:
+		if 'no such table' in str(e):
+			pass
+		else:
+			print(e, file=sys.stderr)
 
 	connection.commit()
 	connection.close()


### PR DESCRIPTION
Search duration limit is 30s. Sometimes it's not enough.

This PR makes the limit dynamic based on past searches.

The endpoint API is readonly. Past search durations are calculated on normal searches.

Fix #52